### PR TITLE
Add: Support for Arbitrary Collections

### DIFF
--- a/lib/jekyll-llmstxt.rb
+++ b/lib/jekyll-llmstxt.rb
@@ -10,11 +10,20 @@ module Jekyll
       site.pages << Jekyll::PageWithoutAFile.new(site, site.source, "", "llms.txt").tap do |file|
         file.content = site.config["title"] ? "# #{site.config["title"]}\n\n" : ""
         file.content += site.config["description"] ? "#{site.config["description"]}\n\n" : ""
-        file.content += "## Posts:\n\n"
 
-        site.posts.docs.each do |post|
-          post_url = site.baseurl ? File.join(site.baseurl, post.url) : post.url
-          file.content += "- [#{post.data["title"]}](#{post_url}index.md)\n"
+        site.collections.each do |collection_name, collection|
+            # Check if the collection has any documents
+            unless collection.docs.empty?
+
+              title_cased_name = collection_name.split.map(&:capitalize).join(' ')
+              file.content += "## #{title_cased_name}:\n\n"
+
+              collection.docs.each do |post|
+                post_url = site.baseurl ? File.join(site.baseurl, post.url) : post.url
+                file.content += "- [#{post.data["title"]}](#{post_url}index.md)\n"
+              end
+              file.content += "\n\n"
+            end
         end
 
         file.data["layout"] = nil
@@ -41,9 +50,11 @@ module Jekyll
 end
 
 Jekyll::Hooks.register :site, :post_write do |site|
-  site.posts.docs.each do |post|
-    target_dir = File.join(site.dest, post.url)
-    target_path = File.join(target_dir, "index.md")
-    FileUtils.cp(post.path, target_path)
+  site.collections.each do |collection_name, collection|
+    collection.docs.each do |post|
+      target_dir = File.join(site.dest, post.url)
+      target_path = File.join(target_dir, "index.md")
+      FileUtils.cp(post.path, target_path)
+    end
   end
 end


### PR DESCRIPTION
Jekyll supports arbitrary collections beyond "posts". Ensure any non-empty collection is included and not just "posts"